### PR TITLE
Add inspect linkages test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
 test:
     requires:
         - nose
+    commands:
+        - conda inspect linkages -n _test pywavelets  # [linux]
 
 about:
     home: https://github.com/PyWavelets/pywt


### PR DESCRIPTION
Ideally we should always run this test when there is a `cython` extension.