### PR TITLE
Update to 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Package license: MIT
 
 Feedstock license: BSD 3-Clause
 
-Summary: Discrete Wavelet Transforms in Python
+Summary: Discrete Wavelet Transforms in Python.
 
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,41 +1,42 @@
-{% set version = "0.5.0" %}
+{% set version = "0.5.1" %}
 
 package:
-    name: pywavelets
-    version: {{ version }}
+  name: pywavelets
+  version: {{ version }}
 
 source:
-    fn: PyWavelets-{{ version }}.tar.gz
-    url: https://github.com/PyWavelets/pywt/archive/v{{ version }}.tar.gz
-    sha256: 99157c11df6c8fb37ca159ce644190a0b9d0c62c830f8a0e2dbe948819c093f3
+  fn: PyWavelets-{{ version }}.tar.gz
+  url: https://github.com/PyWavelets/pywt/archive/v{{ version }}.tar.gz
+  sha256: dc912325b4752b83303af31925450efb795ec81d6aed1317613f7d5a634c0b50
 
 build:
-    number: 0
-    script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
-    build:
-        - python
-        - cython
-        - numpy x.x
-        - setuptools
-    run:
-        - python
-        - numpy x.x
+  build:
+    - python
+    - cython
+    - numpy x.x
+    - setuptools
+  run:
+    - python
+    - numpy x.x
 
 test:
-    requires:
-        - nose
-    commands:
-#        - conda inspect linkages -p ${PREFIX} pywavelets  # [linux]
+  requires:
+    - nose
+  commands:
+    #- conda inspect linkages -p $PREFIX pywavelets  # [not win]
+    #- conda inspect objects -p $PREFIX pywavelets  # [osx]
 
 about:
-    home: https://github.com/PyWavelets/pywt
-    license: MIT
-    summary: Discrete Wavelet Transforms in Python
+  home: https://github.com/PyWavelets/pywt
+  license: MIT
+  summary: 'Discrete Wavelet Transforms in Python.'
 
 extra:
-    recipe-maintainers:
-        - grlee77
-        - jakirkham
-        - ocefpaf
+  recipe-maintainers:
+    - grlee77
+    - jakirkham
+    - ocefpaf


### PR DESCRIPTION
## PyWavelets 0.5.1.

This is a bug-fix only release with no new features as compared to 0.5.0.

PyWavelets is a Python toolbox implementing both discrete and continuous
wavelet transforms (mathematical time-frequency transforms) with a wide
range of built-in wavelets.  C/Cython are used for the low-level routines,
enabling high performance.  Key Features of PyWavelets are:

  * 1D, 2D and nD Forward and Inverse Discrete Wavelet Transform (DWT and
IDWT)
  * 1D, 2D and nD Multilevel DWT and IDWT
  * 1D and 2D Forward and Inverse Stationary Wavelet Transform
  * 1D and 2D Wavelet Packet decomposition and reconstruction
  * 1D Continuous Wavelet Transform
  * When multiple valid implementations are available, we have chosen to
maintain consistency with MATLAB's Wavelet Toolbox.

Bugs Fixed
==========

In release 0.5.0 the wrong edge mode was used for the following three
deprecated mode names: ``ppd``, ``sp1``, and ``per``.  All deprecated edge mode
names are now correctly converted to the corresponding new names.

One-dimensional discrete wavelet transforms did not properly respect the
``axis`` argument for complex-valued data.  Prior to this release, the last
axis was always transformed for arrays with complex dtype.  This fix affects
``dwt``, ``idwt``, ``wavedec``, ``waverec``.