### PR TITLE
switch package source from GitHub to PyPI

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: a12c7a6258c0015d2c75d88b87393ee015494551f049009e8b63eafed2d78efc
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,17 @@
+{% set name = "PyWavelets" %}
 {% set version = "1.0.3" %}
 
 package:
-  name: pywavelets
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/PyWavelets/pywt/archive/v{{ version }}.tar.gz
-  sha256: b152d4b551e3b454217c907e8722f7d8dc0adf104e6b3a8657d07e4020a990f2
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: a12c7a6258c0015d2c75d88b87393ee015494551f049009e8b63eafed2d78efc
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,13 +6,13 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
+  {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: a12c7a6258c0015d2c75d88b87393ee015494551f049009e8b63eafed2d78efc
 
 build:
   number: 1
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   build:


### PR DESCRIPTION
I'm not sure why we had been using GitHub rather than PyPI in this recipe.  I switched to PyPI here just to be more in-line with the preferred conda-forge style
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
