### PR TITLE
Move test running to `meta.yaml`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grlee77 @jakirkham @ocefpaf
+* @grlee77 @jakirkham @ocefpaf @rgommers

--- a/README.md
+++ b/README.md
@@ -327,4 +327,5 @@ Feedstock Maintainers
 * [@grlee77](https://github.com/grlee77/)
 * [@jakirkham](https://github.com/jakirkham/)
 * [@ocefpaf](https://github.com/ocefpaf/)
+* [@rgommers](https://github.com/rgommers/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
   commands:
     {% set label = "'full'" %}
     {% set tests = "['pywt']" %}
-    - python -c "import pywt; pywt.test(verbose=2, label={{ label }}, tests={{ tests }}, extra_argv=['--durations=50'])"
+    - python -c "import sys; import pywt; sys.exit(not pywt.test(verbose=2, label={{ label }}, tests={{ tests }}, extra_argv=['--durations=50']))"
 
 about:
   home: https://github.com/PyWavelets/pywt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,10 @@ test:
     - pytest
   imports:
     - pywt
+  commands:
+    {% set label = "'full'" %}
+    {% set tests = "['pywt']" %}
+    - python -c "import pywt; pywt.test(verbose=2, label={{ label }}, tests={{ tests }}, extra_argv=['--durations=50'])"
 
 about:
   home: https://github.com/PyWavelets/pywt

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,2 +1,0 @@
-import pywt
-pywt.test()


### PR DESCRIPTION
Per our discussion ( https://github.com/conda-forge/pywavelets-feedstock/pull/42#issuecomment-962495719 ) this drops `run_test.py` and moves testing into the `meta.yaml`. Should also fail CI to avoid false positives.

cc @rgommers

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
