### PR TITLE
Add rgommers as maintainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,3 +49,4 @@ extra:
     - grlee77
     - jakirkham
     - ocefpaf
+    - rgommers


### PR DESCRIPTION
[ci skip]

I'm one of the PyWavelets maintainers and was watching this repo anyway, but it seems I was missing from the list of recipe maintainers here.