### PR TITLE
DEV: Try swapping BLAS implementation when emulating

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6cbd69b047bb4e00873097472133425f5f08a4e6bc8b3f0ae709274d4d5e9a8d
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
@@ -32,6 +32,8 @@ requirements:
 test:
   requires:
     - pytest
+    # Possibly avoid some calls unsupported by QEMU
+    - blas=*=*netlib  # [build_platform != target_platform]
   imports:
     - pywt
   commands:


### PR DESCRIPTION
Maybe emulated builds of ppc64le are failing because the BLAS implemenation doesn't support emulation. This PR adds `blas=*=*netlib` to the requirements during the test phase. Since, blas is not a direct dependency I did not add it anywhere else (though it looks like it is present in the build environment because of NumPy).

https://github.com/conda-forge/pywavelets-feedstock/pull/47#issuecomment-973202084

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
